### PR TITLE
fix: Remove requirement `refUnderCursorExists` when using keyboard shortcut to follow a link #127

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "command": "editor.action.openLink",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
-        "when": "editorTextFocus && editorLangId == markdown && memo:refUnderCursorExists"
+        "when": "editorTextFocus && editorLangId == markdown"
       }
     ],
     "menus": {


### PR DESCRIPTION
Please forgive me– I feel like I must be missing something. It reads like we don't want `refUnderCursorExists` to be checked against when using the `Open Link` keyboard shortcut.

Removing this allows for the creation of notes with the shortcut and doesn't break any tests.