### PR TITLE
Enable persistent use of long refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,12 @@
           "scope": "resource",
           "description": "Collapse parent items by default.",
           "type": "boolean"
+        },
+        "memo.linkBehavior.useLongRefsAlways": {
+          "default": false,
+          "scope": "resource",
+          "description": "Include folder paths into the created links. Paths are relative to the workspace root.",
+          "type": "boolean"
         }
       }
     },

--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -11,7 +11,13 @@ import {
 import path from 'path';
 import groupBy from 'lodash.groupby';
 
-import { getWorkspaceCache, fsPathToRef, containsImageExt, containsOtherKnownExts } from '../utils';
+import {
+  getWorkspaceCache,
+  fsPathToRef,
+  containsImageExt,
+  containsOtherKnownExts,
+  getMemoConfigProperty,
+} from '../utils';
 
 const padWithZero = (n: number): string => (n < 10 ? '0' + n : String(n));
 
@@ -71,7 +77,9 @@ export const provideCompletionItems = (document: TextDocument, position: Positio
 
     const item = new CompletionItem(longRef, CompletionItemKind.File);
 
-    item.insertText = isFirstUriInGroup ? shortRef : longRef;
+    const useLongRefsAlways = getMemoConfigProperty('linkBehavior.useLongRefsAlways', false);
+
+    item.insertText = useLongRefsAlways || !isFirstUriInGroup ? longRef : shortRef;
 
     // prepend index with 0, so a lexicographic sort doesn't mess things up
     item.sortText = padWithZero(index);


### PR DESCRIPTION
I prefer to use long references always in my markdown files. This is due to the following reasons:
- The folder hierarchy gives context to the file name; thus to be able to see it in the link makes the link clearer
- IIUC, In a rare case where the user adds a new note into the root of the workspace, and it conflicts with an existing note (residing in one of the subfolders), all existing links to this note start to point to the wrong file (example: 1. [[foo]] points to /bar/foo.md, 2. user adds /foo.md, 3. [[foo]] now points to /foo.md )

This change adds a configuration option to enable persistent use of long refs. By default the behavior stays as currently, but it gives an option to the user to always use long references.