### PR TITLE
feat: Adds flag for syntax decorations

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,13 +80,13 @@
         "memo.linkBehavior.useLongRefsAlways": {
           "default": false,
           "scope": "resource",
-		  "description": "Include folder paths into the created links. Paths are relative to the workspace root.",
+          "description": "Include folder paths into the created links. Paths are relative to the workspace root.",
           "type": "boolean"
-		},
+        },
         "memo.syntaxDecorations.enable": {
           "default": true,
           "scope": "resource",
-          "description": "Enable decorations for wiki-links and other special syntax.",
+          "description": "Enable decorations for links.",
           "type": "boolean"
         }
       }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,13 @@
         "memo.linkBehavior.useLongRefsAlways": {
           "default": false,
           "scope": "resource",
-          "description": "Include folder paths into the created links. Paths are relative to the workspace root.",
+		  "description": "Include folder paths into the created links. Paths are relative to the workspace root.",
+          "type": "boolean"
+		},
+        "memo.syntaxDecorations.enable": {
+          "default": true,
+          "scope": "resource",
+          "description": "Enable decorations for wiki-links and other special syntax. (Requires restart)",
           "type": "boolean"
         }
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "memo.syntaxDecorations.enable": {
           "default": true,
           "scope": "resource",
-          "description": "Enable decorations for wiki-links and other special syntax. (Requires restart)",
+          "description": "Enable decorations for wiki-links and other special syntax.",
           "type": "boolean"
         }
       }

--- a/src/features/syntaxDecorations.spec.ts
+++ b/src/features/syntaxDecorations.spec.ts
@@ -9,7 +9,7 @@ import {
   updateMemoConfigProperty,
 } from '../test/testUtils';
 
-describe.only('getDecorations', () => {
+describe('getDecorations', () => {
   beforeEach(closeEditorsAndCleanWorkspace);
 
   afterEach(closeEditorsAndCleanWorkspace);

--- a/src/features/syntaxDecorations.spec.ts
+++ b/src/features/syntaxDecorations.spec.ts
@@ -6,9 +6,10 @@ import {
   rndName,
   openTextDocument,
   closeEditorsAndCleanWorkspace,
+  updateMemoConfigProperty,
 } from '../test/testUtils';
 
-describe('getDecorations', () => {
+describe.only('getDecorations', () => {
   beforeEach(closeEditorsAndCleanWorkspace);
 
   afterEach(closeEditorsAndCleanWorkspace);
@@ -17,6 +18,24 @@ describe('getDecorations', () => {
     const noteFilename = `${rndName()}.md`;
 
     await createFile(noteFilename);
+
+    const doc = await openTextDocument(noteFilename);
+
+    const editor = await window.showTextDocument(doc);
+
+    expect(getDecorations(editor)).toMatchInlineSnapshot(`
+      Object {
+        "gray": Array [],
+        "lightBlue": Array [],
+      }
+    `);
+  });
+
+  it('should return no decorations when decorations are disabled', async () => {
+    const noteFilename = `${rndName()}.md`;
+
+    await updateMemoConfigProperty('syntaxDecorations.enable', false);
+    await createFile(noteFilename, '[[1234512345]]');
 
     const doc = await openTextDocument(noteFilename);
 

--- a/src/features/syntaxDecorations.ts
+++ b/src/features/syntaxDecorations.ts
@@ -47,6 +47,10 @@ export const getDecorations = (textEditor: TextEditor): { [decorTypeName: string
     decors[decorTypeName] = [];
   });
 
+  if (!getMemoConfigProperty('syntaxDecorations.enable', true)) {
+    return decors;
+  }
+
   doc
     .getText()
     .split(/\r?\n/g)
@@ -126,10 +130,6 @@ const updateDecorations = (textEditor?: TextEditor) => {
 };
 
 export const activate = (context: ExtensionContext) => {
-  if (!getMemoConfigProperty('syntaxDecorations.enable', true)) {
-    return;
-  }
-
   context.subscriptions.push(
     window.onDidChangeActiveTextEditor(updateDecorations),
     workspace.onDidChangeTextDocument((event) => {

--- a/src/features/syntaxDecorations.ts
+++ b/src/features/syntaxDecorations.ts
@@ -15,6 +15,7 @@ import {
   isMdEditor,
   mathEnvCheck,
   refPattern,
+  getMemoConfigProperty,
 } from '../utils';
 
 /*
@@ -125,6 +126,10 @@ const updateDecorations = (textEditor?: TextEditor) => {
 };
 
 export const activate = (context: ExtensionContext) => {
+  if (!getMemoConfigProperty('syntaxDecorations.enable', true)) {
+    return;
+  }
+
   context.subscriptions.push(
     window.onDidChangeActiveTextEditor(updateDecorations),
     workspace.onDidChangeTextDocument((event) => {


### PR DESCRIPTION
This PR is one potential fix for #133. Feel free to close this if another approach is preferable.

This PR adds a new config setting, `memo.syntaxDecorations.enable`, which defaults to `true`. This config setting is then used to short circuit the `activate` function in `syntaxDecorations.ts`