### PR TITLE
fix: Fix backlink error when filenames contain regex symbols

### DIFF
--- a/src/features/BacklinksTreeDataProvider.ts
+++ b/src/features/BacklinksTreeDataProvider.ts
@@ -104,9 +104,7 @@ export default class BacklinksTreeDataProvider implements vscode.TreeDataProvide
           collapsibleState,
         );
         backlink.description = `(${referencesByPath[pathParam].length}) ${trimSlashes(
-          pathParam
-            .replace(workspaceFolder.uri.fsPath, '')
-            .replace(new RegExp(`${path.basename(pathParam)}$`), ''),
+          pathParam.replace(workspaceFolder.uri.fsPath, '').replace(path.basename(pathParam), ''),
         )}`;
         backlink.tooltip = pathParam;
         backlink.command = {


### PR DESCRIPTION
This regex replace was causing the backlink tree generation to fail when filenames looked like broken patterns.

To reproduce, create a backlink to a file named `?.md` (for example).

Love this extention btw. ❤️