### PR TITLE
feat: Add symlinks ignoring in completition provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,12 @@
           "description": "Whether to enable links completion in the editor. Reload required!",
           "type": "boolean"
         },
+        "memo.links.completion.removeRedundantSymlinks": {
+          "default": false,
+          "scope": "resource",
+          "description": "Whether to remove redundant symlinked files from suggestions.",
+          "type": "boolean"
+        },
         "memo.links.following.enabled": {
           "default": true,
           "scope": "resource",

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -73,6 +73,36 @@ export const createFile = async (
   return Uri.file(path.join(workspaceFolder, ...filename.split('/')));
 };
 
+export const createSymlink = async (
+  filename: string,
+  target: string,
+  syncCache: boolean = true,
+): Promise<Uri | undefined> => {
+  const workspaceFolder = utils.getWorkspaceFolder();
+
+  if (!workspaceFolder) {
+    return;
+  }
+
+  const filepath = path.join(workspaceFolder, ...filename.split('/'));
+  const dirname = path.dirname(filepath);
+  const targetpath = path.join(workspaceFolder, ...target.split('/'));
+
+  utils.ensureDirectoryExists(filepath);
+
+  if (!fs.existsSync(dirname)) {
+    throw new Error(`Directory ${dirname} does not exist`);
+  }
+
+  fs.symlinkSync(targetpath, filepath);
+
+  if (syncCache) {
+    await cacheWorkspace();
+  }
+
+  return Uri.file(path.join(workspaceFolder, ...filename.split('/')));
+};
+
 export const fileExists = (filename: string) => {
   const workspaceFolder = utils.getWorkspaceFolder();
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -237,6 +237,7 @@ export function getConfigProperty<T>(property: string, fallback: T): T {
 export type MemoBoolConfigProp =
   | 'decorations.enabled'
   | 'links.completion.enabled'
+  | 'links.completion.removeRedundantSymlinks'
   | 'links.following.enabled'
   | 'links.preview.enabled'
   | 'links.references.enabled'


### PR DESCRIPTION
Hello. I often use symlinks in my knowledge base. I use folders as tags and often many files need multiple tags, so I create symlinks to such files in all required tag folders. However, vscode-memo does not distinguish between files and symlinks to them, so even if only one file exists with a given basename and several symlinks to this file, long links are still used in completitions. This PR adds proper support for symlinks in completitions - they are properly ignored when appropriate when choosing between inserting long or short links, and it is also possible to remove redundant links from completitions altogether. Also "aliases" are handled correctly - symbolic links with names that differ from the target file. The new tests are probably better at explaining how it all works. 