### PR TITLE
perf: Add completion items caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,12 @@
           "description": "Whether to enable links completion in the editor. Reload required!",
           "type": "boolean"
         },
+        "memo.links.completion.removeRedundantSymlinks": {
+          "default": false,
+          "scope": "resource",
+          "description": "Whether to remove redundant symlinked files from suggestions.",
+          "type": "boolean"
+        },
         "memo.links.following.enabled": {
           "default": true,
           "scope": "resource",

--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -1,26 +1,6 @@
-import {
-  languages,
-  TextDocument,
-  Position,
-  CompletionItem,
-  workspace,
-  CompletionItemKind,
-  Uri,
-  ExtensionContext,
-} from 'vscode';
-import fs from 'fs';
-import path from 'path';
-import groupBy from 'lodash.groupby';
+import { languages, TextDocument, Position, ExtensionContext } from 'vscode';
 
-import {
-  getWorkspaceCache,
-  fsPathToRef,
-  containsImageExt,
-  containsOtherKnownExts,
-  getMemoConfigProperty,
-} from '../utils';
-
-const padWithZero = (n: number): string => (n < 10 ? '0' + n : String(n));
+import { getWorkspaceCache } from '../utils';
 
 export const provideCompletionItems = (document: TextDocument, position: Position) => {
   const linePrefix = document.lineAt(position).text.substr(0, position.character);
@@ -28,102 +8,16 @@ export const provideCompletionItems = (document: TextDocument, position: Positio
   const isResourceAutocomplete = linePrefix.match(/\!\[\[\w*$/);
   const isDocsAutocomplete = linePrefix.match(/\[\[\w*$/);
 
-  if (!isDocsAutocomplete && !isResourceAutocomplete) {
+  if (isResourceAutocomplete) {
+    return [
+      ...getWorkspaceCache().resourcesCompletionItems,
+      ...getWorkspaceCache().refsCompletionItems,
+    ];
+  } else if (isDocsAutocomplete) {
+    return [...getWorkspaceCache().docsCompletionItems, ...getWorkspaceCache().refsCompletionItems];
+  } else {
     return undefined;
   }
-
-  const completionItems: CompletionItem[] = [];
-
-  const uris: Uri[] = [
-    ...(isResourceAutocomplete
-      ? [...getWorkspaceCache().imageUris, ...getWorkspaceCache().markdownUris]
-      : []),
-    ...(!isResourceAutocomplete
-      ? [
-          ...getWorkspaceCache().markdownUris,
-          ...getWorkspaceCache().imageUris,
-          ...getWorkspaceCache().otherUris,
-        ]
-      : []),
-  ];
-
-  const urisByPathBasename = groupBy(uris, ({ fsPath }) => path.basename(fsPath).toLowerCase());
-
-  for (const basename in urisByPathBasename) {
-    const urisByCanonical = groupBy(urisByPathBasename[basename], (uri) =>
-      fs.realpathSync(uri.fsPath),
-    );
-    const unique = Object.values(urisByCanonical).map((uris) => uris[0]); // take random one, e.g. first
-    urisByPathBasename[basename] = unique;
-  }
-
-  uris.forEach((uri, index) => {
-    const workspaceFolder = workspace.getWorkspaceFolder(uri);
-
-    if (!workspaceFolder) {
-      return;
-    }
-
-    const longRef = fsPathToRef({
-      path: uri.fsPath,
-      basePath: workspaceFolder.uri.fsPath,
-      keepExt: containsImageExt(uri.fsPath) || containsOtherKnownExts(uri.fsPath),
-    });
-
-    const shortRef = fsPathToRef({
-      path: uri.fsPath,
-      keepExt: containsImageExt(uri.fsPath) || containsOtherKnownExts(uri.fsPath),
-    });
-
-    const urisGroup = urisByPathBasename[path.basename(uri.fsPath).toLowerCase()] || [];
-
-    const searchResult = urisGroup.findIndex((uriParam) => uriParam.fsPath === uri.fsPath);
-
-    const isFirstUriInGroup = searchResult === 0;
-
-    // if all other files with the same basename were symlinks then urisGroup.length will be 1
-    // and some uris in main array will be missing in group - that's ok
-    const isSymlinked = searchResult === -1 && urisGroup.length === 1;
-
-    if (isSymlinked && getMemoConfigProperty('links.completion.removeRedundantSymlinks', false)) {
-      return;
-    }
-
-    if (!longRef || !shortRef) {
-      return;
-    }
-
-    const item = new CompletionItem(longRef, CompletionItemKind.File);
-
-    const linksFormat = getMemoConfigProperty('links.format', 'short');
-
-    item.insertText =
-      linksFormat === 'long' || linksFormat === 'absolute' || (!isFirstUriInGroup && !isSymlinked)
-        ? longRef
-        : shortRef;
-
-    // prepend index with 0, so a lexicographic sort doesn't mess things up
-    item.sortText = padWithZero(index);
-
-    completionItems.push(item);
-  });
-
-  const danglingRefs = getWorkspaceCache().danglingRefs;
-
-  const completionItemsLength = completionItems.length;
-
-  danglingRefs.forEach((ref, index) => {
-    const item = new CompletionItem(ref, CompletionItemKind.File);
-
-    item.insertText = ref;
-
-    // prepend index with 0, so a lexicographic sort doesn't mess things up
-    item.sortText = padWithZero(completionItemsLength + index);
-
-    completionItems.push(item);
-  });
-
-  return completionItems;
 };
 
 export const activate = (context: ExtensionContext) =>

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -73,6 +73,36 @@ export const createFile = async (
   return Uri.file(path.join(workspaceFolder, ...filename.split('/')));
 };
 
+export const createSymlink = async (
+  filename: string,
+  target: string,
+  syncCache: boolean = true,
+): Promise<Uri | undefined> => {
+  const workspaceFolder = utils.getWorkspaceFolder();
+
+  if (!workspaceFolder) {
+    return;
+  }
+
+  const filepath = path.join(workspaceFolder, ...filename.split('/'));
+  const dirname = path.dirname(filepath);
+  const targetpath = path.join(workspaceFolder, ...target.split('/'));
+
+  utils.ensureDirectoryExists(filepath);
+
+  if (!fs.existsSync(dirname)) {
+    throw new Error(`Directory ${dirname} does not exist`);
+  }
+
+  fs.symlinkSync(targetpath, filepath);
+
+  if (syncCache) {
+    await cacheWorkspace();
+  }
+
+  return Uri.file(path.join(workspaceFolder, ...filename.split('/')));
+};
+
 export const fileExists = (filename: string) => {
   const workspaceFolder = utils.getWorkspaceFolder();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Uri, Location } from 'vscode';
+import { Uri, Location, CompletionItem } from 'vscode';
 
 export type WorkspaceCache = {
   imageUris: Uri[];
@@ -7,6 +7,9 @@ export type WorkspaceCache = {
   allUris: Uri[];
   danglingRefs: string[];
   danglingRefsByFsPath: { [key: string]: string[] };
+  docsCompletionItems: CompletionItem[];
+  resourcesCompletionItems: CompletionItem[];
+  refsCompletionItems: CompletionItem[];
 };
 
 export type RefT = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -237,6 +237,7 @@ export function getConfigProperty<T>(property: string, fallback: T): T {
 export type MemoBoolConfigProp =
   | 'decorations.enabled'
   | 'links.completion.enabled'
+  | 'links.completion.removeRedundantSymlinks'
   | 'links.following.enabled'
   | 'links.preview.enabled'
   | 'links.references.enabled'


### PR DESCRIPTION
This PR adds proper completion items caching. My home folder is quite large and I place all my notes deep inside the file tree, so the number of `md` files, image files and other files is quite significant (~2500 real files and ~**12000** of possible file paths) and completion appears with a small but annoying delay. Now hints appear instantly and performance is limited only by VSCode itself.